### PR TITLE
Add macOS native binary build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,33 @@
-name: build-linux
+name: build-native
 on: [push]
 #  schedule:
 #    - cron: '0 0 * * *'
 jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install mercurial
+      run: brew install hg
+    - name: Check out SDL sources
+      run: |
+        hg clone https://hg.libsdl.org/SDL /tmp/SDL
+    - name: Build binaries
+      run: |
+        cd /tmp/SDL
+        ./configure
+        make
+        make install
+    - name: copy built binary
+      run: cp /usr/local/lib/libSDL2-2.0.0.dylib native/osx-x64/libSDL2.dylib
+    - name: Create pull request
+      uses: peter-evans/create-pull-request@v2
+      with:
+        commit-message: Update macOS SDL binaries
+        title: Update macOS SDL binaries
+        body: This PR has been auto-generated to update the macOS SDL binaries.
+        branch: update-macos-binaries
+
   build-linux:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Tested to [work](https://github.com/peppy/SDL2-CS/actions/runs/353358060) and fix the crash I'm experiencing on startup.

Attempted to add a windows build task but it's a mess at the moment (bash doesn't exist on github action runner and the visual studio build instructions don't match the files available in the SDL repo; the only sln file is targeting visual studio 2003).