### PR TITLE
Rework CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,66 +1,108 @@
 name: build-native
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+    inputs: {}
 #  schedule:
 #    - cron: '0 0 * * *'
-jobs:
-  build-macos:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Check out SDL sources
-      run: |
-        git clone --depth 1 https://github.com/ppy/SDL.git /tmp/SDL
-    - uses: devbotsxyz/xcode-select@v1
-      with:
-        version: "10.3"
-    - name: Build binaries
-      run: |
-        cd /tmp/SDL
-        ./configure
-        make
-        make install
-      env:
-        MACOSX_DEPLOYMENT_TARGET: '10.14'
-        DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
-    - name: copy built binary
-      run: cp /usr/local/lib/libSDL2-2.0.0.dylib native/osx-x64/libSDL2.dylib
-    - name: Create pull request
-      uses: peter-evans/create-pull-request@v2
-      with:
-        commit-message: Update macOS SDL binaries
-        title: Update macOS SDL binaries
-        body: This PR has been auto-generated to update the macOS SDL binaries.
-        branch: update-macos-binaries
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+env:
+  BUILD_TYPE: Release
 
-  build-linux:
-    runs-on: ubuntu-latest
+jobs:
+  build:
+    name: ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - { name: win-x64,   os: windows-latest, flags: -A x64                                                                            }
+        - { name: win-x86,   os: windows-latest, flags: -A Win32                                                                          }
+        - { name: win-arm64, os: windows-latest, flags: -A ARM64                                                                          }
+        - { name: linux-x64, os: ubuntu-20.04,   flags: -GNinja , target_apt_arch: ":amd64"                                               }
+        - { name: linux-x86, os: ubuntu-20.04,   flags: -GNinja, cmake_configure_env: CFLAGS=-m32 CXXFLAGS=-m32, target_apt_arch: ":i386" }
+        - { name: osx-x64,   os: macos-latest,   flags: -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET="10.14"          }
+        # NOTE: macOS 11.0 is the first released supported by Apple Silicon.
+        - { name: osx-arm64, os: macos-latest,   flags: -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0"            }
     steps:
+    - name: Setup Linux dependencies
+      if: runner.os == 'Linux'
+      run: |
+        # TODO: only run this command on i386
+        sudo dpkg --add-architecture i386
+        sudo apt-get update -y -qq
+        sudo apt-get install wayland-protocols${{ matrix.platform.target_apt_arch }} \
+          pkg-config${{ matrix.platform.target_apt_arch }} \
+          ninja-build${{ matrix.platform.target_apt_arch }} \
+          libasound2-dev${{ matrix.platform.target_apt_arch }} \
+          libdbus-1-dev${{ matrix.platform.target_apt_arch }} \
+          libegl1-mesa-dev${{ matrix.platform.target_apt_arch }} \
+          libgl1-mesa-dev${{ matrix.platform.target_apt_arch }} \
+          libgles2-mesa-dev${{ matrix.platform.target_apt_arch }} \
+          libglu1-mesa-dev${{ matrix.platform.target_apt_arch }} \
+          libibus-1.0-dev${{ matrix.platform.target_apt_arch }} \
+          libpulse-dev${{ matrix.platform.target_apt_arch }} \
+          libsdl2-2.0-0${{ matrix.platform.target_apt_arch }} \
+          libsndio-dev${{ matrix.platform.target_apt_arch }} \
+          libudev-dev${{ matrix.platform.target_apt_arch }} \
+          libwayland-dev${{ matrix.platform.target_apt_arch }} \
+          libx11-dev${{ matrix.platform.target_apt_arch }} \
+          libxcursor-dev${{ matrix.platform.target_apt_arch }} \
+          libxext-dev${{ matrix.platform.target_apt_arch }} \
+          libxi-dev${{ matrix.platform.target_apt_arch }} \
+          libxinerama-dev${{ matrix.platform.target_apt_arch }} \
+          libxkbcommon-dev${{ matrix.platform.target_apt_arch }} \
+          libxrandr-dev${{ matrix.platform.target_apt_arch }} \
+          libxss-dev${{ matrix.platform.target_apt_arch }} \
+          libxt-dev${{ matrix.platform.target_apt_arch }} \
+          libxv-dev${{ matrix.platform.target_apt_arch }} \
+          libxxf86vm-dev${{ matrix.platform.target_apt_arch }} \
+          libdrm-dev${{ matrix.platform.target_apt_arch }} \
+          libgbm-dev${{ matrix.platform.target_apt_arch }} \
+          libpulse-dev${{ matrix.platform.target_apt_arch }} \
+          libwayland-client++0$ \
+          libwayland-cursor++0$ \
+          wayland-scanner++ \
+          gcc-multilib \
+          g++-multilib
     - uses: actions/checkout@v2
-    - name: Check out SDL sources
-      run: |
-        git clone --depth 1 https://github.com/ppy/SDL.git /tmp/SDL
-    - name: Build i386 binaries
-      run: |
-        mkdir /tmp/i386
-        cd linux-build
-        docker build -t sdl2-i386 -f Dockerfile.i386 .
-        docker run -v `pwd`/compile:/entry -v /tmp/i386:/io -v /tmp/SDL:/src sdl2-i386
-        cp /tmp/i386/lib/libSDL2-2.0.so.0 ../native/linux-x86/libSDL2.so
-    - name: Build amd64 binaries
-      run: |
-        mkdir /tmp/amd64
-        cd linux-build
-        docker build -t sdl2-amd64 -f Dockerfile.amd64 .
-        docker run -v `pwd`/compile:/entry -v /tmp/amd64:/io -v /tmp/SDL:/src sdl2-amd64
-        cp /tmp/amd64/lib/libSDL2-2.0.so.0 ../native/linux-x64/libSDL2.so
+      with:
+        repository: libsdl-org/SDL
+    - uses: actions/checkout@v2
+      with:
+        path: 'SDL2-CS'
+    - name: Configure CMake
+      run:  ${{ matrix.platform.cmake_configure_env }} cmake -B build ${{ matrix.platform.flags }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSDL_SHARED_ENABLED_BY_DEFAULT=ON -DSDL_STATIC_ENABLED_BY_DEFAULT=ON
+    - name: Build
+      run: cmake --build build/ --config Release
+    - name: Install (Windows)
+      run: cmake --install build/ --prefix install_output --config Release
+      if: runner.os == 'Windows'
+    - name: Install
+      run: sudo cmake --install build/ --prefix install_output --config Release
+      if: runner.os != 'Windows'
+    - name: Prepare release directory (Windows)
+      run: mkdir -Force SDL2-CS/native/${{ matrix.platform.name }}
+      if: runner.os == 'Windows'
+    - name: Prepare release directory
+      run: mkdir -p SDL2-CS/native/${{ matrix.platform.name }}
+      if: runner.os != 'Windows'
+    - name: Prepare release (Windows)
+      run: cp install_output/bin/SDL2.dll SDL2-CS/native/${{ matrix.platform.name }}/SDL2.dll
+      if: runner.os == 'Windows'
+    - name: Prepare release (Linux)
+      run: cp install_output/lib/libSDL2-2.0.so.1 SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.so
+      if: runner.os == 'Linux'
+    - name: Prepare release (OSX)
+      run: cp install_output/lib/libSDL2-2.0.dylib SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.dylib
+      if: runner.os == 'macOS'
     - name: Create pull request
       uses: peter-evans/create-pull-request@v2
       with:
-        commit-message: Update Linux SDL binaries
-        title: Update Linux SDL binaries
-        body: This PR has been auto-generated to update the Linux SDL binaries.
-        branch: update-linux-binaries
+        commit-message: Update ${{ matrix.platform.name }} SDL binaries
+        title: Update ${{ matrix.platform.name }} SDL binaries
+        body: This PR has been auto-generated to update the ${{ matrix.platform.name }} SDL binaries.
+        branch: update-${{ matrix.platform.name }}-binaries
+        path: 'SDL2-CS'
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           g++-multilib
     - uses: actions/checkout@v2
       with:
-        repository: libsdl-org/SDL
+        repository: ppy/SDL
     - uses: actions/checkout@v2
       with:
         path: 'SDL2-CS'


### PR DESCRIPTION
This rework current CI to build on all standard platform and architectures.

The following changes were made:
- Adds support for Windows x86, x64 and ARM64 builds
- Adds support for macOS arm64
- Use cmake instead of autoconf
- All artifacts are now build in Release instead of Debug
- A matrix is now used instead of individual steps to deduplicate steps and to allow adding new target architecture with a single line
- If build of one job fails, it will now let others continue instead of cancelling them
- The action can now be triggered via a manual workflow