### PR TITLE
Edited SDL_OpenAudioDevice() to allow for default device selection

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -7660,10 +7660,10 @@ namespace SDL2
 			out SDL_AudioSpec obtained,
 			int allowed_changes
 		) {
-			int utf8DeviceBufSize = Utf8Size(device);
+			int utf8DeviceBufSize = Utf8SizeNullable(device);
 			byte* utf8Device = stackalloc byte[utf8DeviceBufSize];
 			return INTERNAL_SDL_OpenAudioDevice(
-				Utf8Encode(device, utf8Device, utf8DeviceBufSize),
+				Utf8EncodeNullable(device, utf8Device, utf8DeviceBufSize),
 				iscapture,
 				ref desired,
 				out obtained,


### PR DESCRIPTION
Edited `SDL_OpenAudioDevice()` to use `Utf8SizeNullable()` and `Utf8EncodeNullable()` over the non-nullable version. This lets `SDL_OpenAudioDevice()` open the "most reasonable default device" by passing `null` as the device, rather than having to use `SDL_GetAudioDeviceName()` as shown on the SDL2 wiki [here](https://wiki.libsdl.org/SDL_OpenAudioDevice).