### PR TITLE
Add missing includes for available binaries

### DIFF
--- a/SDL2-CS.csproj
+++ b/SDL2-CS.csproj
@@ -22,6 +22,11 @@
             <PackagePath>runtimes/win-x64/native</PackagePath>
             <Pack>true</Pack>
         </Content>
+        <Content Include="$(MSBuildThisFileDirectory)native\win-arm64\SDL2.dll">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <PackagePath>runtimes/win-arm64/native</PackagePath>
+            <Pack>true</Pack>
+        </Content>
         <Content Include="$(MSBuildThisFileDirectory)native\win-x86\SDL2.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <PackagePath>runtimes/win-x86/native</PackagePath>

--- a/SDL2-CS.csproj
+++ b/SDL2-CS.csproj
@@ -32,6 +32,11 @@
             <PackagePath>runtimes/osx-x64/native</PackagePath>
             <Pack>true</Pack>
         </Content>
+        <Content Include="$(MSBuildThisFileDirectory)native\osx-arm64\libSDL2.dylib">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <PackagePath>runtimes/osx-arm64/native</PackagePath>
+            <Pack>true</Pack>
+        </Content>
         <Content Include="$(MSBuildThisFileDirectory)native\linux-x64\libSDL2.so">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <PackagePath>runtimes/linux-x64/native</PackagePath>


### PR DESCRIPTION
Seems like we already have binaries for OSX & Win ARM64, we just needed to include them.