### PR TITLE
Fix linux platform workflow failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       run: cp install_output/bin/SDL2.dll SDL2-CS/native/${{ matrix.platform.name }}/SDL2.dll
       if: runner.os == 'Windows'
     - name: Prepare release (Linux)
-      run: cp install_output/lib/libSDL2-2.0.so.1 SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.so
+      run: cp install_output/lib/libSDL2-2.0.so.0 SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.so
       if: runner.os == 'Linux'
     - name: Prepare release (OSX)
       run: cp install_output/lib/libSDL2-2.0.dylib SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.dylib


### PR DESCRIPTION
The [ppy/SDL](https://github.com/ppy/SDL) fork pulled changes from upstream just recently, including [this](https://github.com/libsdl-org/SDL/commit/e2234ee97c929345b065fe355fe6c8d2a394f2af) commit which broke the linux workflows.

This updates the workflows file to use the correct filenames as per the mentioned commit, for the workflows to work back again.

---

Success build at https://github.com/frenzibyte/SDL2-CS/runs/3153567716?check_suite_focus=true.