### PR TITLE
Fix `DllNotFoundException` on iOS when using AOT compilation

### DIFF
--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -37,10 +37,9 @@ namespace SDL2
 {
 	public static class SDL
 	{
-		static SDL()
+		public static void PrepareLibraryForIOS()
 		{
-			if (OperatingSystem.IsIOS())
-				NativeLibrary.SetDllImportResolver(typeof(SDL).Assembly, (_, assembly, path) => NativeLibrary.Load("@rpath/SDL2.framework/SDL2", assembly, path));
+			NativeLibrary.SetDllImportResolver(typeof(SDL).Assembly, (_, assembly, path) => NativeLibrary.Load("@rpath/SDL2.framework/SDL2", assembly, path));
 		}
 
 		#region SDL2# Variables


### PR DESCRIPTION
Seems with AOT .NET/Mono looks up the library first before executing the static constructor where the resolvers are setup. Changed to explicit static method instead.