### PR TITLE
Add libdecor support for SDL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,9 @@ jobs:
       run: cp install_output/bin/SDL2.dll SDL2-CS/native/${{ matrix.platform.name }}/SDL2.dll
       if: runner.os == 'Windows'
     - name: Prepare release (Linux)
-      run: cp install_output/lib/libSDL2-2.0.so.0 SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.so
+      run: |
+        cp install_output/lib/libSDL2-2.0.so.0 SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.so
+        cp install_output/lib/libdecor-0.so.0.100.1 SDL2-CS/native/${{ matrix.platform.name }}/libdecor-0.so
       if: runner.os == 'Linux'
     - name: Prepare release (macOS)
       run: cp install_output/lib/libSDL2-2.0.dylib SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.dylib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,11 +77,14 @@ jobs:
     - name: Build libdecor
       if: runner.os == 'Linux'
       run: |
+        pwd
         git clone https://gitlab.freedesktop.org/libdecor/libdecor.git
         cd libdecor
         git checkout 0.1.1
-        meson build -Ddemo=false
+        meson build -Ddemo=false -Dprefix=/usr
         sudo meson install -C build
+        meson build-workflow -Ddemo=false -Dprefix=install_output
+        meson install -C build-workflow
     - uses: actions/checkout@v3
       with:
         repository: 'libsdl-org/SDL'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           wayland-scanner++ \
           wayland-protocols \
           meson \
-          libpangocairo-1.0-0 \
+          libpango1.0-dev \
           pkg-config${{ matrix.platform.target_apt_arch }} \
           libasound2-dev${{ matrix.platform.target_apt_arch }} \
           libdbus-1-dev${{ matrix.platform.target_apt_arch }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         cd libdecor
         git checkout 0.1.1
         meson build -Ddemo=false
-        meson install -C build
+        sudo meson install -C build
     - uses: actions/checkout@v3
       with:
         repository: 'libsdl-org/SDL'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
       run: |
         cp install_output/lib/libSDL2-2.0.so.0 SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.so
         cp /usr/lib/x86_64-linux-gnu/libdecor-0.so.0.100.1 SDL2-CS/native/${{ matrix.platform.name }}/libdecor-0.so
+        cp /usr/lib/x86_64-linux-gnu/libdecor SDL2-CS/native/${{ matrix.platform.name }}/libdecor
       if: runner.os == 'Linux'
     - name: Prepare release (macOS)
       run: cp install_output/lib/libSDL2-2.0.dylib SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.dylib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,14 @@ jobs:
           libdrm-dev${{ matrix.platform.target_apt_arch }} \
           libgbm-dev${{ matrix.platform.target_apt_arch }} \
           libpulse-dev${{ matrix.platform.target_apt_arch }}
+    - name: Build libdecor
+      if: runner.os == 'Linux'
+      run: |
+        git clone https://gitlab.freedesktop.org/libdecor/libdecor.git
+        cd libdecor
+        git checkout 0.1.1
+        meson build -Ddemo=false
+        meson install -C build
     - uses: actions/checkout@v3
       with:
         repository: 'libsdl-org/SDL'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         git checkout 0.1.1
         meson build -Ddemo=false -Dprefix=/usr
         sudo meson install -C build
-        meson build-workflow -Ddemo=false -Dprefix=install_output
+        meson build-workflow -Ddemo=false -Dprefix=$HOME/install_output
         meson install -C build-workflow
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
           wayland-scanner++ \
           wayland-protocols \
           meson \
+          libpangocairo \
           pkg-config${{ matrix.platform.target_apt_arch }} \
           libasound2-dev${{ matrix.platform.target_apt_arch }} \
           libdbus-1-dev${{ matrix.platform.target_apt_arch }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,8 +83,6 @@ jobs:
         git checkout 0.1.1
         meson build -Ddemo=false -Dprefix=/usr
         sudo meson install -C build
-        meson build-workflow -Ddemo=false -Dprefix=$HOME/install_output
-        meson install -C build-workflow
     - uses: actions/checkout@v3
       with:
         repository: 'libsdl-org/SDL'
@@ -114,7 +112,7 @@ jobs:
     - name: Prepare release (Linux)
       run: |
         cp install_output/lib/libSDL2-2.0.so.0 SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.so
-        cp install_output/lib/libdecor-0.so.0.100.1 SDL2-CS/native/${{ matrix.platform.name }}/libdecor-0.so
+        cp /usr/lib/x86_64-linux-gnu/libdecor-0.so.0.100.1 SDL2-CS/native/${{ matrix.platform.name }}/libdecor-0.so
       if: runner.os == 'Linux'
     - name: Prepare release (macOS)
       run: cp install_output/lib/libSDL2-2.0.dylib SDL2-CS/native/${{ matrix.platform.name }}/libSDL2.dylib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           wayland-scanner++ \
           wayland-protocols \
           meson \
-          libpangocairo \
+          libpangocairo-1.0-0 \
           pkg-config${{ matrix.platform.target_apt_arch }} \
           libasound2-dev${{ matrix.platform.target_apt_arch }} \
           libdbus-1-dev${{ matrix.platform.target_apt_arch }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,6 @@ jobs:
     - name: Build libdecor
       if: runner.os == 'Linux'
       run: |
-        pwd
         git clone https://gitlab.freedesktop.org/libdecor/libdecor.git
         cd libdecor
         git checkout 0.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
           ninja-build \
           wayland-scanner++ \
           wayland-protocols \
+          meson \
           pkg-config${{ matrix.platform.target_apt_arch }} \
           libasound2-dev${{ matrix.platform.target_apt_arch }} \
           libdbus-1-dev${{ matrix.platform.target_apt_arch }} \


### PR DESCRIPTION
This pull request will make the build-native github workflow build libdecor before SDL, this ensures that SDL is built with runtime-linking libdecor support. Additionally, this also copies the resulting libdecor library to the `native`  directory.